### PR TITLE
Fix stock analysis createdAt

### DIFF
--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -486,9 +486,8 @@ export default function AdminPage() {
         name: newStockAnalysisName,
         strategy: newStockAnalysisStrategy,
         detail: newStockAnalysisDetail,
-        status: newStockAnalysisStatus, 
-        returnRate: newStockAnalysisReturnRate, 
-        date: new Date().toISOString().split('T')[0], 
+        status: newStockAnalysisStatus,
+        returnRate: newStockAnalysisReturnRate,
         updatedAt: new Date(),
       };
 
@@ -1051,7 +1050,7 @@ export default function AdminPage() {
                       <div key={analysis.id} className="bg-gray-700 p-4 rounded-lg shadow-md flex flex-col justify-between">
                         <div>
                           <h3 className="text-xl font-semibold text-white mb-2">{analysis.name}</h3>
-                          <p className="text-gray-400 text-sm mb-1">등록일: {analysis.date}</p>
+                          <p className="text-gray-400 text-sm mb-1">등록일: {analysis.createdAt ? new Date(analysis.createdAt.toDate()).toLocaleDateString('ko-KR') : '날짜 없음'}</p>
                           <p className="text-gray-400 text-sm mb-1">전략: {analysis.strategy}</p>
                           <p className="text-gray-400 text-sm mb-1">설명: {analysis.detail}</p>
                           {/* 💡 상태 및 수익률 표시 */}

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -428,7 +428,7 @@ export default function Home() {
                       {favorites.includes(stock.id) ? "❤️" : "🤍"}
                     </button>
                   </div>
-                  <p className="text-xs text-gray-400 mb-3">업데이트: {stock.date}</p>
+                  <p className="text-xs text-gray-400 mb-3">업데이트: {stock.createdAt ? new Date(stock.createdAt.toDate()).toLocaleDateString('ko-KR') : ''}</p>
                   <p className="text-gray-300 text-sm mb-3 recommendation-item-content">
                     <strong>전략:</strong> {stock.strategy || "등록된 전략 없음"}
                   </p>

--- a/src/RecommendationsPage.jsx
+++ b/src/RecommendationsPage.jsx
@@ -97,7 +97,7 @@ export default function RecommendationsPage() {
 
               return (
                 <tr key={analysis.id} className="border-b border-gray-600 hover:bg-gray-500">
-                  <td className="px-6 py-4">{analysis.date}</td>
+                  <td className="px-6 py-4">{analysis.createdAt ? new Date(analysis.createdAt.toDate()).toLocaleDateString('ko-KR') : ''}</td>
                   <td className="px-6 py-4 font-medium text-white">{analysis.name}</td>
                   <td className="px-6 py-4">{analysis.strategy}</td>
                   <td className="px-6 py-4">{analysis.detail}</td>


### PR DESCRIPTION
## Summary
- avoid modifying created date when updating stock analyses
- show createdAt for stock analyses

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861f47643248323adbbee929a050b5d