### PR TITLE
feat: add portfolio monitoring workflow

### DIFF
--- a/backend/portfolio_updater.py
+++ b/backend/portfolio_updater.py
@@ -1,0 +1,189 @@
+"""포트폴리오 종목 가격 데이터를 갱신하고 상태를 업데이트하는 스크립트."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Tuple
+
+from google.cloud import firestore
+from pykrx import stock
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+FIRESTORE_COLLECTION_PRICES = "stockPrices"
+PORTFOLIO_COLLECTION = "portfolioStocks"
+BATCH_WRITE_LIMIT = 400
+FETCH_DAYS = 365
+
+
+def get_all_tickers() -> List[str]:
+    """코스피·코스닥 전체 종목 코드를 리스트로 반환합니다."""
+
+    kospi = stock.get_market_ticker_list(market="KOSPI")
+    kosdaq = stock.get_market_ticker_list(market="KOSDAQ")
+    tickers = sorted(set(kospi) | set(kosdaq))
+    LOGGER.info("총 %d개의 종목 코드를 수집했습니다.", len(tickers))
+    return tickers
+
+
+def fetch_price_history(ticker: str) -> List[Dict[str, object]]:
+    """단일 종목의 1년치 일별 시세를 조회해 직렬화 가능한 리스트로 변환합니다."""
+
+    end_date = datetime.today()
+    start_date = end_date - timedelta(days=FETCH_DAYS)
+    df = stock.get_market_ohlcv_by_date(
+        start_date.strftime("%Y%m%d"),
+        end_date.strftime("%Y%m%d"),
+        ticker,
+    )
+
+    if df.empty:
+        LOGGER.warning("%s 종목에서 가격 데이터를 찾을 수 없습니다.", ticker)
+        return []
+
+    df = df.reset_index().rename(
+        columns={
+            "날짜": "date",
+            "시가": "open",
+            "고가": "high",
+            "저가": "low",
+            "종가": "close",
+            "거래량": "volume",
+        }
+    )
+
+    df["date"] = df["date"].dt.strftime("%Y-%m-%d")
+    records: List[Dict[str, object]] = df.to_dict(orient="records")
+    return records
+
+
+def commit_in_batches(
+    db: firestore.Client,
+    writes: Iterable[Tuple[firestore.DocumentReference, Dict[str, object]]],
+) -> None:
+    """Firestore 배치 쓰기를 수행합니다."""
+
+    batch = db.batch()
+    counter = 0
+    for counter, (doc_ref, data) in enumerate(writes, start=1):
+        batch.set(doc_ref, data)
+        if counter % BATCH_WRITE_LIMIT == 0:
+            batch.commit()
+            batch = db.batch()
+    if counter % BATCH_WRITE_LIMIT != 0:
+        batch.commit()
+
+
+def update_stock_prices(db: firestore.Client, tickers: List[str]) -> None:
+    """주가 정보를 Firestore에 저장합니다."""
+
+    updates: List[Tuple[firestore.DocumentReference, Dict[str, object]]] = []
+    for ticker in tickers:
+        try:
+            prices = fetch_price_history(ticker)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("%s 종목 가격 수집 실패", ticker)
+            continue
+
+        doc_ref = db.collection(FIRESTORE_COLLECTION_PRICES).document(ticker)
+        updates.append(
+            (
+                doc_ref,
+                {
+                    "ticker": ticker,
+                    "prices": prices,
+                    "updatedAt": firestore.SERVER_TIMESTAMP,
+                },
+            )
+        )
+
+    if updates:
+        commit_in_batches(db, updates)
+        LOGGER.info("총 %d개 종목 가격을 Firestore에 반영했습니다.", len(updates))
+
+
+def calculate_progress(legs: List[Dict[str, object]], last_price: float) -> Dict[str, float]:
+    """매수·매도 레그 정보를 기반으로 진행률과 완료 개수를 계산합니다."""
+
+    buy_legs = [leg for leg in legs if leg.get("type") == "BUY"]
+    sell_legs = [leg for leg in legs if leg.get("type") == "SELL"]
+
+    buy_completed = sum(1 for leg in buy_legs if last_price <= float(leg.get("targetPrice", 0)))
+    sell_completed = sum(1 for leg in sell_legs if last_price >= float(leg.get("targetPrice", 0)))
+
+    buy_total = len(buy_legs)
+    sell_total = len(sell_legs)
+
+    buy_progress = buy_completed / max(buy_total, 1)
+    sell_progress = sell_completed / max(sell_total, 1)
+
+    return {
+        "buyCompleted": buy_completed,
+        "sellCompleted": sell_completed,
+        "buyProgress": buy_progress,
+        "sellProgress": sell_progress,
+        "totalProgress": min(1.0, (buy_progress + sell_progress) / 2),
+        "buyTotal": buy_total,
+        "sellTotal": sell_total,
+    }
+
+
+def update_portfolio_status(db: firestore.Client) -> None:
+    """포트폴리오 종목 상태를 최신 가격에 맞춰 갱신합니다."""
+
+    portfolio_ref = db.collection(PORTFOLIO_COLLECTION)
+    price_ref = db.collection(FIRESTORE_COLLECTION_PRICES)
+
+    for stock_doc in portfolio_ref.stream():
+        data = stock_doc.to_dict()
+        ticker = data.get("ticker")
+        if not ticker:
+            LOGGER.warning("%s 문서에 종목 코드가 없습니다.", stock_doc.id)
+            continue
+
+        price_snapshot = price_ref.document(ticker).get()
+        if not price_snapshot.exists:
+            LOGGER.warning("%s 종목의 가격 정보가 없습니다.", ticker)
+            continue
+
+        prices = price_snapshot.to_dict().get("prices", [])
+        if not prices:
+            LOGGER.warning("%s 종목의 가격 리스트가 비어 있습니다.", ticker)
+            continue
+
+        last_price = float(prices[-1]["close"])
+        legs = [leg_doc.to_dict() for leg_doc in stock_doc.reference.collection("legs").stream()]
+
+        progress = calculate_progress(legs, last_price)
+
+        status = "진행전"
+        if progress["buyCompleted"] > 0:
+            status = "진행중"
+        if progress["buyCompleted"] == len([leg for leg in legs if leg.get("type") == "BUY"]) and progress[
+            "sellCompleted"
+        ] == len([leg for leg in legs if leg.get("type") == "SELL"]):
+            status = "완료"
+
+        update_payload = {
+            "lastPrice": last_price,
+            "status": status,
+            "statusUpdatedAt": firestore.SERVER_TIMESTAMP,
+            **progress,
+        }
+        stock_doc.reference.update(update_payload)
+        LOGGER.info("%s 종목 상태를 %s로 갱신했습니다.", ticker, status)
+
+
+def main() -> None:
+    """스크립트 실행 진입점."""
+
+    db = firestore.Client()
+    tickers = get_all_tickers()
+    update_stock_prices(db, tickers)
+    update_portfolio_status(db)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,7 @@ beautifulsoup4
 google-generativeai
 certifi
 gunicorn
+pandas
+pykrx
+google-cloud-firestore
+google-cloud-storage

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import ForumDetailPage from "./ForumDetailPage";
 import AdminPage from "./AdminPage";
 import AiSummaryListPage from "./AiSummaryListPage";
 import AiSummaryDetailPage from "./AiSummaryDetailPage";
+import PortfolioPage from "./PortfolioPage";
 import CausalInference from "./pages/CausalInference";
 // NewsDetailPage는 이제 필요 없으므로 제거
 
@@ -30,6 +31,7 @@ function App() {
       <Route path="/forum/:postId" element={<ForumDetailPage />} />
       <Route path="/admin" element={<AdminPage />} />
       <Route path="/causal" element={<CausalInference />} />
+      <Route path="/portfolio" element={<PortfolioPage />} />
 
       {/* AI 시장 이슈 요약 관련 라우트 */}
       <Route path="/ai-summaries" element={<AiSummaryListPage />} />

--- a/src/PortfolioPage.jsx
+++ b/src/PortfolioPage.jsx
@@ -1,0 +1,349 @@
+import { useEffect, useMemo, useState } from "react";
+import { Helmet } from "react-helmet";
+import { collection, doc, serverTimestamp, setDoc } from "firebase/firestore";
+import usePortfolioData from "./hooks/usePortfolioData";
+import { db } from "./firebaseConfig";
+import useAuth from "./useAuth";
+
+function ProgressBar({ value }) {
+  const percentage = Math.max(0, Math.min(100, Math.round((value ?? 0) * 100)));
+
+  return (
+    <div className="w-full bg-gray-700 h-2 rounded">
+      <div
+        className="bg-teal-400 h-2 rounded transition-all duration-300"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+}
+
+function StockRow({ stock, onSelect }) {
+  const statusColor =
+    stock.status === "완료"
+      ? "text-emerald-400"
+      : stock.status === "진행중"
+      ? "text-yellow-400"
+      : "text-gray-300";
+
+  return (
+    <tr
+      className="border-b border-gray-700 hover:bg-gray-800 cursor-pointer"
+      onClick={() => onSelect(stock)}
+    >
+      <td className="px-4 py-3 font-semibold text-white">{stock.ticker}</td>
+      <td className="px-4 py-3">{stock.name}</td>
+      <td className={`px-4 py-3 ${statusColor}`}>{stock.status ?? "-"}</td>
+      <td className="px-4 py-3">
+        <ProgressBar value={stock.totalProgress} />
+      </td>
+      <td className="px-4 py-3 text-right">
+        {typeof stock.aggregatedReturn === "number"
+          ? `${stock.aggregatedReturn.toFixed(2)}%`
+          : "-"}
+      </td>
+    </tr>
+  );
+}
+
+function MemberNoteForm({ stock }) {
+  const { user, signIn } = useAuth();
+  const [form, setForm] = useState({ buyPrice: "", quantity: "", memo: "" });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (stock?.memberNote) {
+      setForm({
+        buyPrice: stock.memberNote.buyPrice ?? "",
+        quantity: stock.memberNote.quantity ?? "",
+        memo: stock.memberNote.memo ?? "",
+      });
+    } else {
+      setForm({ buyPrice: "", quantity: "", memo: "" });
+    }
+  }, [stock]);
+
+  if (!user) {
+    return (
+      <div className="bg-gray-800 rounded-lg p-4 text-sm text-gray-300 space-y-3">
+        <p>로그인 후 나의 매매 정보를 기록할 수 있습니다.</p>
+        <button
+          type="button"
+          onClick={signIn}
+          className="w-full bg-teal-500 hover:bg-teal-400 text-white font-semibold py-2 rounded"
+        >
+          구글 계정으로 로그인
+        </button>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!stock) return;
+    setSaving(true);
+    try {
+      const noteRef = doc(
+        collection(doc(db, "portfolioStocks", stock.id), "memberNotes"),
+        user.uid
+      );
+
+      await setDoc(
+        noteRef,
+        {
+          uid: user.uid,
+          buyPrice: form.buyPrice === "" ? null : Number(form.buyPrice),
+          quantity: form.quantity === "" ? null : Number(form.quantity),
+          memo: form.memo,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+      alert("저장되었습니다.");
+    } catch (error) {
+      console.error("회원 메모 저장 실패", error);
+      alert("저장에 실패했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-gray-800 rounded-lg p-4 space-y-3 text-sm"
+    >
+      <div>
+        <label className="block text-gray-300 mb-1" htmlFor="buyPrice">
+          나의 평균 매수가
+        </label>
+        <input
+          id="buyPrice"
+          type="number"
+          step="0.01"
+          value={form.buyPrice}
+          onChange={(event) =>
+            setForm((prev) => ({ ...prev, buyPrice: event.target.value }))
+          }
+          className="w-full rounded bg-gray-900 border border-gray-700 px-3 py-2 text-white"
+          placeholder="예: 12345"
+        />
+      </div>
+      <div>
+        <label className="block text-gray-300 mb-1" htmlFor="quantity">
+          보유 수량(주)
+        </label>
+        <input
+          id="quantity"
+          type="number"
+          step="1"
+          value={form.quantity}
+          onChange={(event) =>
+            setForm((prev) => ({ ...prev, quantity: event.target.value }))
+          }
+          className="w-full rounded bg-gray-900 border border-gray-700 px-3 py-2 text-white"
+          placeholder="예: 10"
+        />
+      </div>
+      <div>
+        <label className="block text-gray-300 mb-1" htmlFor="memo">
+          메모
+        </label>
+        <textarea
+          id="memo"
+          rows={3}
+          value={form.memo}
+          onChange={(event) =>
+            setForm((prev) => ({ ...prev, memo: event.target.value }))
+          }
+          className="w-full rounded bg-gray-900 border border-gray-700 px-3 py-2 text-white"
+          placeholder="내 전략이나 체크하고 싶은 내용을 입력하세요."
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={saving}
+        className="w-full bg-teal-500 hover:bg-teal-400 disabled:opacity-60 text-white font-semibold py-2 rounded"
+      >
+        {saving ? "저장 중..." : "나의 매매 기록 저장"}
+      </button>
+    </form>
+  );
+}
+
+export default function PortfolioPage() {
+  const { loading, stocks } = usePortfolioData();
+  const [selectedStock, setSelectedStock] = useState(null);
+
+  useEffect(() => {
+    if (!stocks.length) {
+      setSelectedStock(null);
+      return;
+    }
+
+    setSelectedStock((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const matched = stocks.find((stock) => stock.id === prev.id);
+      return matched ?? null;
+    });
+  }, [stocks]);
+
+  const summary = useMemo(() => {
+    if (!stocks.length) {
+      return { totalWeight: 0, averageReturn: 0 };
+    }
+
+    const totalWeight = stocks.reduce(
+      (acc, stock) => acc + (Number(stock.targetWeight) || 0),
+      0
+    );
+    const averageReturn =
+      stocks.reduce(
+        (acc, stock) => acc + (Number(stock.aggregatedReturn) || 0),
+        0
+      ) / stocks.length;
+
+    return { totalWeight, averageReturn };
+  }, [stocks]);
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100">
+      <Helmet>
+        <title>포트폴리오 현황 - 지지저항 Lab</title>
+        <meta
+          name="description"
+          content="유료 회원을 위한 종목별 매수/매도 전략 및 실시간 진행 상황"
+        />
+      </Helmet>
+
+      <header className="px-6 py-8 border-b border-gray-800">
+        <h1 className="text-3xl font-bold text-white mb-2">유료 회원 포트폴리오 현황</h1>
+        <p className="text-gray-400">
+          전체 목표 비중 {summary.totalWeight.toFixed(1)}% · 평균 수익률 {" "}
+          {summary.averageReturn.toFixed(2)}%
+        </p>
+      </header>
+
+      <main className="px-6 py-8 space-y-8">
+        <section className="bg-gray-800 rounded-xl shadow-lg">
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-gray-700 text-gray-300 uppercase">
+                <tr>
+                  <th className="px-4 py-3">종목코드</th>
+                  <th className="px-4 py-3">종목명</th>
+                  <th className="px-4 py-3">상태</th>
+                  <th className="px-4 py-3">진행률</th>
+                  <th className="px-4 py-3 text-right">총 수익률</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-6 text-center text-gray-400">
+                      데이터를 불러오는 중입니다...
+                    </td>
+                  </tr>
+                )}
+                {!loading && !stocks.length && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-6 text-center text-gray-400">
+                      아직 등록된 포트폴리오가 없습니다.
+                    </td>
+                  </tr>
+                )}
+                {!loading &&
+                  stocks.map((stock) => (
+                    <StockRow
+                      key={stock.id}
+                      stock={stock}
+                      onSelect={setSelectedStock}
+                    />
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {selectedStock && (
+          <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+            <div className="bg-gray-800 rounded-xl p-6 space-y-4">
+              <div className="flex justify-between items-center">
+                <div>
+                  <h2 className="text-xl font-semibold text-white">
+                    {selectedStock.name} ({selectedStock.ticker})
+                  </h2>
+                  <p className="text-sm text-gray-400">
+                    목표 비중 {(Number(selectedStock.targetWeight) || 0).toFixed(1)}%
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSelectedStock(null)}
+                  className="text-sm text-gray-400 hover:text-gray-200"
+                >
+                  닫기
+                </button>
+              </div>
+
+              <div>
+                <h3 className="text-gray-300 font-semibold mb-2">매수 전략</h3>
+                <ul className="space-y-2 text-sm">
+                  {selectedStock.buyLegs?.length ? (
+                    selectedStock.buyLegs.map((leg) => (
+                      <li
+                        key={`buy-${leg.id}`}
+                        className="flex justify-between bg-gray-900 px-3 py-2 rounded border border-gray-700"
+                      >
+                        <span>
+                          {leg.sequence}차 매수 · 목표 {leg.targetPrice}원
+                        </span>
+                        <span className="text-gray-400">
+                          비중 {(Number(leg.weight) * 100 || 0).toFixed(1)}%
+                        </span>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-gray-400">등록된 매수 전략이 없습니다.</li>
+                  )}
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-gray-300 font-semibold mb-2">매도 전략</h3>
+                <ul className="space-y-2 text-sm">
+                  {selectedStock.sellLegs?.length ? (
+                    selectedStock.sellLegs.map((leg) => (
+                      <li
+                        key={`sell-${leg.id}`}
+                        className="flex justify-between bg-gray-900 px-3 py-2 rounded border border-gray-700"
+                      >
+                        <span>
+                          {leg.sequence}차 매도 · 목표 {leg.targetPrice}원
+                        </span>
+                        <span className="text-gray-400">
+                          비중 {(Number(leg.weight) * 100 || 0).toFixed(1)}%
+                        </span>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-gray-400">등록된 매도 전략이 없습니다.</li>
+                  )}
+                </ul>
+              </div>
+
+              <div className="bg-gray-900 rounded-lg px-4 py-3 text-sm text-gray-300">
+                {selectedStock.strategyNote || "전략 설명이 없습니다."}
+              </div>
+            </div>
+
+            <MemberNoteForm stock={selectedStock} />
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/hooks/usePortfolioData.js
+++ b/src/hooks/usePortfolioData.js
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  onSnapshot,
+  orderBy,
+  query,
+} from "firebase/firestore";
+import { db } from "../firebaseConfig";
+import useAuth from "../useAuth";
+
+function sortLegs(legs = []) {
+  const sorted = [...legs].sort((a, b) => (a.sequence || 0) - (b.sequence || 0));
+  return sorted;
+}
+
+export default function usePortfolioData() {
+  const { user } = useAuth();
+  const [stocks, setStocks] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const portfolioQuery = query(
+      collection(db, "portfolioStocks"),
+      orderBy("orderIndex", "asc")
+    );
+
+    const unsubscribe = onSnapshot(
+      portfolioQuery,
+      async (snapshot) => {
+        try {
+          const result = await Promise.all(
+            snapshot.docs.map(async (stockDoc) => {
+              const stockData = { id: stockDoc.id, ...stockDoc.data() };
+
+              const legsSnap = await getDocs(collection(stockDoc.ref, "legs"));
+              const legs = legsSnap.docs.map((legDoc) => ({
+                id: legDoc.id,
+                ...legDoc.data(),
+              }));
+
+              const buyLegs = sortLegs(legs.filter((leg) => leg.type === "BUY"));
+              const sellLegs = sortLegs(legs.filter((leg) => leg.type === "SELL"));
+
+              let memberNote = null;
+              if (user) {
+                const noteRef = doc(stockDoc.ref, "memberNotes", user.uid);
+                const noteSnap = await getDoc(noteRef);
+                if (noteSnap.exists()) {
+                  memberNote = { id: noteSnap.id, ...noteSnap.data() };
+                }
+              }
+
+              return {
+                ...stockData,
+                buyLegs,
+                sellLegs,
+                memberNote,
+              };
+            })
+          );
+
+          setStocks(result);
+          setLoading(false);
+        } catch (error) {
+          console.error("포트폴리오 데이터를 불러오지 못했습니다.", error);
+          setStocks([]);
+          setLoading(false);
+        }
+      },
+      (error) => {
+        console.error("포트폴리오 구독 실패", error);
+        setStocks([]);
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [user]);
+
+  const computedStocks = useMemo(() => {
+    return stocks.map((stock) => {
+      const buyLegs = stock.buyLegs ?? [];
+      const sellLegs = stock.sellLegs ?? [];
+
+      const buyCompleted = buyLegs.filter((leg) => leg.filled).length;
+      const sellCompleted = sellLegs.filter((leg) => leg.filled).length;
+      const buyProgress = buyLegs.length
+        ? buyCompleted / buyLegs.length
+        : 0;
+      const sellProgress = sellLegs.length
+        ? sellCompleted / sellLegs.length
+        : 0;
+
+      return {
+        ...stock,
+        buyProgress,
+        sellProgress,
+        totalProgress: Math.min(1, (buyProgress + sellProgress) / 2),
+      };
+    });
+  }, [stocks]);
+
+  return { loading, stocks: computedStocks };
+}


### PR DESCRIPTION
## Summary
- add a dedicated portfolio monitoring page that lists strategy progress and lets members record their trades
- create a reusable hook to stream portfolio documents, legs, and per-user notes from Firestore
- add a Firestore batch updater script and required dependencies for daily price refresh and status calculation

## Testing
- npm install *(fails: registry returned 403 for cytoscape)*

------
https://chatgpt.com/codex/tasks/task_e_68e131ba393c832399933076af1d6f6b