### PR TITLE
Fix admin login by routing API calls through Netlify proxy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,10 @@
 [build]
   command = "npm run build && node generate-sitemap.cjs && node generate-rss.cjs"
   publish = "dist"
+
+[[redirects]]
+  from = "/api/*"
+  to = "https://stock-lab-backend-repo.onrender.com/api/:splat"
+  status = 200
+  force = true
+  headers = {Access-Control-Allow-Origin = "*"}

--- a/src/lib/apiConfig.js
+++ b/src/lib/apiConfig.js
@@ -1,6 +1,23 @@
-const DEFAULT_API_BASE_URL = "https://stock-lab-backend-repo.onrender.com";
+const FALLBACK_REMOTE_API = "https://stock-lab-backend-repo.onrender.com";
 
-export const API_BASE_URL =
-  import.meta?.env?.VITE_API_BASE_URL?.trim() || DEFAULT_API_BASE_URL;
+const inferSameOriginApiBase = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const { hostname } = window.location;
+
+  if (hostname.endsWith("netlify.app") || hostname.endsWith("netlify.live")) {
+    // Netlify에서는 netlify.toml 리다이렉트 설정을 통해 백엔드로 프록시합니다.
+    return "";
+  }
+
+  return null;
+};
+
+const inferredBase = inferSameOriginApiBase();
+const envBase = import.meta?.env?.VITE_API_BASE_URL?.trim();
+
+export const API_BASE_URL = envBase || inferredBase || FALLBACK_REMOTE_API;
 
 export default API_BASE_URL;


### PR DESCRIPTION
## Summary
- add a Netlify redirect so `/api/*` requests are proxied to the Render backend with CORS headers
- update the API base URL helper to reuse the Netlify origin when available and fall back to the remote backend otherwise

## Testing
- npm install --no-progress *(fails: npm ERR! 403 403 Forbidden - GET https://registry.npmjs.org/@eslint%2fjs)*

------
https://chatgpt.com/codex/tasks/task_e_68e1401c56888323b481f84359e89bf9