### PR TITLE
Improve portfolio execution tracking summary

### DIFF
--- a/src/PortfolioPage.jsx
+++ b/src/PortfolioPage.jsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { collection, doc, serverTimestamp, setDoc } from "firebase/firestore";
 import usePortfolioData from "./hooks/usePortfolioData";
-import useStockPrices from "./hooks/useStockPrices";
 import { db } from "./firebaseConfig";
 import useAuth from "./useAuth";
 
@@ -175,46 +174,101 @@ function MemberNoteForm({ stock }) {
 export default function PortfolioPage() {
   const { loading, stocks } = usePortfolioData();
   const [selectedStock, setSelectedStock] = useState(null);
-  const {
-    prices: priceHistory,
-    loading: priceLoading,
-    error: priceError,
-  } = useStockPrices(selectedStock?.ticker, { days: 400 });
-  const recentPrices = useMemo(() => {
-    if (!priceHistory.length) {
+  const priceSeries = useMemo(() => {
+    if (!selectedStock?.priceHistory) {
       return [];
     }
 
-    return priceHistory
-      .map((item) => ({
-        original: item,
-        dateValue: new Date(item.date),
-      }))
-      .filter(
-        (item) =>
-          item.dateValue instanceof Date &&
-          !Number.isNaN(item.dateValue.getTime())
-      )
+    const toDate = (value) => {
+      if (!value) return null;
+      if (value instanceof Date) {
+        return value;
+      }
+      if (typeof value.toDate === "function") {
+        try {
+          const converted = value.toDate();
+          if (converted instanceof Date && !Number.isNaN(converted.getTime())) {
+            return converted;
+          }
+        } catch (error) {
+          console.warn("가격 데이터 변환 실패", error);
+        }
+      }
+      const parsed = new Date(value);
+      return parsed instanceof Date && !Number.isNaN(parsed.getTime()) ? parsed : null;
+    };
+
+    return (Array.isArray(selectedStock.priceHistory)
+      ? selectedStock.priceHistory
+      : []
+    )
+      .map((item) => {
+        const dateValue = toDate(item.date ?? item.timestamp);
+        const close = Number(
+          item.close ?? item.price ?? item.closePrice ?? item.endPrice
+        );
+
+        if (!Number.isFinite(close) || !dateValue) {
+          return null;
+        }
+
+        return {
+          ...item,
+          close,
+          date: item.date ?? item.timestamp ?? dateValue.toISOString().slice(0, 10),
+          dateValue,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.dateValue - b.dateValue);
+  }, [selectedStock]);
+
+  const recentPrices = useMemo(() => {
+    if (!priceSeries.length) {
+      return [];
+    }
+
+    return [...priceSeries]
       .sort((a, b) => b.dateValue - a.dateValue)
       .slice(0, 10)
-      .map((item) => item.original);
-  }, [priceHistory]);
+      .map((item) => ({ date: item.date, close: item.close }));
+  }, [priceSeries]);
 
-  const targetAnalysis = useMemo(() => {
-    if (!selectedStock || !priceHistory.length) {
+  const legAnalysis = useMemo(() => {
+    if (!selectedStock) {
       return {
         buyLegs: [],
         sellLegs: [],
         reachedLegs: [],
         unreachedLegs: [],
+        allLegs: [],
       };
     }
 
-    const parsedPrices = priceHistory
+    const toSafeDate = (value) => {
+      if (!value) return null;
+      if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return value;
+      }
+      if (typeof value.toDate === "function") {
+        try {
+          const converted = value.toDate();
+          if (converted instanceof Date && !Number.isNaN(converted.getTime())) {
+            return converted;
+          }
+        } catch (error) {
+          console.warn("타임스탬프 변환 실패", error);
+        }
+      }
+      const parsed = new Date(value);
+      return parsed instanceof Date && !Number.isNaN(parsed.getTime()) ? parsed : null;
+    };
+
+    const parsedPrices = priceSeries
       .map((item) => ({
         ...item,
         close: Number(item.close),
-        dateValue: new Date(item.date),
+        dateValue: item.dateValue instanceof Date ? item.dateValue : new Date(item.date),
       }))
       .filter(
         (item) =>
@@ -224,26 +278,56 @@ export default function PortfolioPage() {
       );
 
     if (!parsedPrices.length) {
+      const fallbackAnalyse = (legs, type) =>
+        (Array.isArray(legs) ? legs : []).map((leg) => ({
+          id: leg?.id ?? `${type}-${leg?.sequence ?? ""}-${leg?.targetPrice ?? ""}`,
+          sequence: leg.sequence,
+          type,
+          targetPrice: Number.isFinite(Number(leg.targetPrice))
+            ? Number(leg.targetPrice)
+            : null,
+          rawTargetPrice: leg.targetPrice,
+          reached: false,
+          reachedDate: null,
+          reachedDateValue: null,
+          daysToHit: null,
+          maxAdversePercent: null,
+          filled: Boolean(leg?.filled),
+          createdAt: toSafeDate(leg?.createdAt),
+          filledAt: toSafeDate(leg?.filledAt),
+          startDate: toSafeDate(leg?.createdAt) ?? toSafeDate(selectedStock?.createdAt),
+        }));
+
+      const buyLegs = fallbackAnalyse(selectedStock.buyLegs, "buy");
+      const sellLegs = fallbackAnalyse(selectedStock.sellLegs, "sell");
+      const allLegs = [...buyLegs, ...sellLegs];
+
       return {
-        buyLegs: [],
-        sellLegs: [],
+        buyLegs,
+        sellLegs,
         reachedLegs: [],
         unreachedLegs: [],
+        allLegs,
       };
     }
 
     const firstDate = parsedPrices[0].dateValue;
     const millisecondsPerDay = 1000 * 60 * 60 * 24;
 
-    const closes = parsedPrices.map((price) => price.close);
-    const maxPrice = Math.max(...closes);
-    const minPrice = Math.min(...closes);
+    const stockCreatedAt = toSafeDate(selectedStock?.createdAt) ?? firstDate;
 
     const analyseLegs = (legs, type) =>
       (Array.isArray(legs) ? legs : []).map((leg) => {
         const numericTarget = Number(leg.targetPrice);
         const hasValidTarget = Number.isFinite(numericTarget);
         const baseId = leg?.id ?? `${type}-${leg?.sequence ?? ""}-${leg?.targetPrice ?? ""}`;
+
+        const legCreatedAt = toSafeDate(leg?.createdAt);
+        const startDateCandidate = legCreatedAt ?? stockCreatedAt;
+        const startDate =
+          startDateCandidate instanceof Date && !Number.isNaN(startDateCandidate.getTime())
+            ? startDateCandidate
+            : firstDate;
 
         if (!hasValidTarget) {
           return {
@@ -256,31 +340,59 @@ export default function PortfolioPage() {
             reachedDate: null,
             daysToHit: null,
             maxAdversePercent: null,
+            filled: Boolean(leg?.filled),
+            createdAt: legCreatedAt,
+            filledAt: toSafeDate(leg?.filledAt),
+            startDate,
           };
         }
 
-        const hitIndex = parsedPrices.findIndex((price) =>
+        const relevantPrices = parsedPrices.filter((price) => price.dateValue >= startDate);
+        const scopedPrices = relevantPrices.length ? relevantPrices : parsedPrices;
+        const baselineDate = relevantPrices.length
+          ? relevantPrices[0].dateValue
+          : scopedPrices.length
+          ? scopedPrices[0].dateValue
+          : startDate;
+
+        const hitIndex = scopedPrices.findIndex((price) =>
           type === "buy" ? price.close <= numericTarget : price.close >= numericTarget
         );
 
         const reached = hitIndex !== -1;
-        const reachedInfo = reached ? parsedPrices[hitIndex] : null;
+        const reachedInfo = reached ? scopedPrices[hitIndex] : null;
 
-        const daysToHit = reachedInfo
-          ? Math.max(
-              0,
-              Math.round(
-                (reachedInfo.dateValue.getTime() - firstDate.getTime()) /
-                  millisecondsPerDay
+        const daysToHit =
+          reachedInfo && baselineDate
+            ? Math.max(
+                0,
+                Math.round(
+                  (reachedInfo.dateValue.getTime() - baselineDate.getTime()) /
+                    millisecondsPerDay
+                )
               )
-            )
-          : null;
+            : null;
 
-        const maxAdversePercent = reached
-          ? null
-          : type === "buy"
-          ? ((maxPrice - numericTarget) / numericTarget) * 100
-          : ((numericTarget - minPrice) / numericTarget) * 100;
+        let maxAdversePercent = null;
+        if (!reached && scopedPrices.length) {
+          const scopedCloses = scopedPrices.map((price) => price.close);
+          const scopedMax = Math.max(...scopedCloses);
+          const scopedMin = Math.min(...scopedCloses);
+
+          if (type === "buy" && Number.isFinite(scopedMax)) {
+            maxAdversePercent = ((scopedMax - numericTarget) / numericTarget) * 100;
+          } else if (type === "sell" && Number.isFinite(scopedMin)) {
+            maxAdversePercent = ((numericTarget - scopedMin) / numericTarget) * 100;
+          }
+        }
+
+        if (maxAdversePercent != null) {
+          if (!Number.isFinite(maxAdversePercent)) {
+            maxAdversePercent = null;
+          } else {
+            maxAdversePercent = Math.max(0, maxAdversePercent);
+          }
+        }
 
         return {
           id: baseId,
@@ -290,11 +402,13 @@ export default function PortfolioPage() {
           rawTargetPrice: leg.targetPrice,
           reached,
           reachedDate: reachedInfo ? reachedInfo.date : null,
+          reachedDateValue: reachedInfo ? reachedInfo.dateValue : null,
           daysToHit,
-          maxAdversePercent:
-            maxAdversePercent != null && Number.isFinite(maxAdversePercent)
-              ? Math.max(0, maxAdversePercent)
-              : null,
+          maxAdversePercent,
+          filled: Boolean(leg?.filled),
+          createdAt: legCreatedAt,
+          filledAt: toSafeDate(leg?.filledAt),
+          startDate,
         };
       });
 
@@ -309,8 +423,78 @@ export default function PortfolioPage() {
       unreachedLegs: allLegs.filter(
         (leg) => !leg.reached && leg.maxAdversePercent != null
       ),
+      allLegs,
     };
-  }, [priceHistory, selectedStock]);
+  }, [priceSeries, selectedStock]);
+
+  const executionSummary = useMemo(() => {
+    const legs = legAnalysis.allLegs ?? [];
+    if (!legs.length) {
+      return {
+        total: 0,
+        filled: 0,
+        reached: 0,
+        pending: 0,
+        items: [],
+      };
+    }
+
+    const items = legs
+      .map((leg) => ({
+        ...leg,
+        status: leg.filled ? "filled" : leg.reached ? "reached" : "pending",
+      }))
+      .sort((a, b) => {
+        const typePriority = a.type === b.type ? 0 : a.type === "buy" ? -1 : 1;
+        if (typePriority !== 0) return typePriority;
+        return (a.sequence ?? 0) - (b.sequence ?? 0);
+      });
+
+    const filled = items.filter((item) => item.status === "filled").length;
+    const reached = items.filter((item) => item.status === "reached").length;
+    const pending = items.filter((item) => item.status === "pending").length;
+
+    return {
+      total: items.length,
+      filled,
+      reached,
+      pending,
+      items,
+    };
+  }, [legAnalysis]);
+
+  const formatDate = (value) => {
+    if (!value) return "-";
+    let dateValue = value;
+    if (typeof value?.toDate === "function") {
+      try {
+        dateValue = value.toDate();
+      } catch (error) {
+        console.warn("날짜 변환 실패", error);
+        dateValue = value;
+      }
+    }
+
+    if (!(dateValue instanceof Date)) {
+      dateValue = new Date(dateValue);
+    }
+
+    if (!(dateValue instanceof Date) || Number.isNaN(dateValue.getTime())) {
+      return "-";
+    }
+
+    return dateValue.toISOString().slice(0, 10);
+  };
+
+  const formatTargetPrice = (value, fallback) => {
+    if (Number.isFinite(value)) {
+      return `${value.toLocaleString()}원`;
+    }
+    if (fallback) {
+      return fallback;
+    }
+    return "-";
+  };
 
   useEffect(() => {
     if (!stocks.length) {
@@ -473,19 +657,30 @@ export default function PortfolioPage() {
               </div>
 
               <div>
-                <h3 className="text-gray-300 font-semibold mb-2">
-                  목표가 백테스트 결과
-                </h3>
-                {priceLoading ? (
-                  <p className="text-sm text-gray-400">
-                    목표가 백테스트를 위한 가격 데이터를 불러오는 중입니다...
-                  </p>
-                ) : priceError ? (
-                  <p className="text-sm text-red-400">
-                    목표가 백테스트를 수행하지 못했습니다. 잠시 후 다시 시도해주세요.
-                  </p>
-                ) : priceHistory.length ? (
+                <h3 className="text-gray-300 font-semibold mb-2">설정 이후 실행 여부</h3>
+                {executionSummary.total ? (
                   <div className="space-y-4">
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      <div className="bg-gray-900 rounded-lg p-3 text-center">
+                        <p className="text-xs text-gray-400">체결 완료</p>
+                        <p className="text-lg font-semibold text-emerald-400">
+                          {executionSummary.filled} / {executionSummary.total}
+                        </p>
+                      </div>
+                      <div className="bg-gray-900 rounded-lg p-3 text-center">
+                        <p className="text-xs text-gray-400">가격 도달</p>
+                        <p className="text-lg font-semibold text-teal-400">
+                          {executionSummary.reached}
+                        </p>
+                      </div>
+                      <div className="bg-gray-900 rounded-lg p-3 text-center">
+                        <p className="text-xs text-gray-400">대기 중</p>
+                        <p className="text-lg font-semibold text-yellow-400">
+                          {executionSummary.pending}
+                        </p>
+                      </div>
+                    </div>
+
                     <div className="overflow-x-auto">
                       <table className="min-w-full text-sm">
                         <thead className="bg-gray-900 text-gray-300">
@@ -493,163 +688,67 @@ export default function PortfolioPage() {
                             <th className="px-3 py-2 text-left">구분</th>
                             <th className="px-3 py-2 text-left">차수</th>
                             <th className="px-3 py-2 text-right">목표가</th>
-                            <th className="px-3 py-2 text-left">도달 여부</th>
-                            <th className="px-3 py-2 text-left">도달까지 기간</th>
-                            <th className="px-3 py-2 text-right">미도달 시 최대 손실</th>
+                            <th className="px-3 py-2 text-left">설정일</th>
+                            <th className="px-3 py-2 text-left">현재 상태</th>
+                            <th className="px-3 py-2 text-left">추가 정보</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {[...targetAnalysis.buyLegs, ...targetAnalysis.sellLegs].map(
-                            (leg) => {
-                              const targetPriceText = Number.isFinite(leg.targetPrice)
-                                ? `${leg.targetPrice.toLocaleString()}원`
-                                : leg.rawTargetPrice ?? "-";
+                          {executionSummary.items.map((leg) => {
+                            const statusText =
+                              leg.status === "filled"
+                                ? "체결 완료"
+                                : leg.status === "reached"
+                                ? "목표가 도달"
+                                : "진행 대기";
 
-                              return (
-                                <tr key={leg.id} className="border-b border-gray-700">
-                                  <td className="px-3 py-2 text-gray-300">
-                                    {leg.type === "buy" ? "매수" : "매도"}
-                                  </td>
-                                  <td className="px-3 py-2">{leg.sequence}차</td>
-                                  <td className="px-3 py-2 text-right text-white">
-                                    {targetPriceText}
-                                  </td>
-                                  <td className="px-3 py-2 text-gray-200">
-                                    {leg.reached
-                                      ? `도달 (${leg.reachedDate})`
-                                      : "미도달"}
-                                </td>
-                                <td className="px-3 py-2 text-gray-200">
-                                  {leg.daysToHit != null
-                                    ? `${leg.daysToHit}일`
-                                    : "-"}
-                                </td>
-                                <td className="px-3 py-2 text-right text-gray-200">
-                                    {leg.maxAdversePercent != null
-                                      ? `${leg.maxAdversePercent.toFixed(1)}%`
-                                      : "-"}
-                                  </td>
-                                </tr>
-                              );
+                            let detailText = "-";
+                            if (leg.status === "filled") {
+                              detailText = leg.filledAt
+                                ? `${formatDate(leg.filledAt)} 체결`
+                                : "회원 기록 기준";
+                            } else if (leg.status === "reached") {
+                              const reachedDate = leg.reachedDateValue
+                                ? formatDate(leg.reachedDateValue)
+                                : leg.reachedDate ?? "-";
+                              const durationText =
+                                leg.daysToHit != null ? `${leg.daysToHit}일 소요` : "기간 정보 없음";
+                              detailText = `${reachedDate} · ${durationText}`;
+                            } else if (Number.isFinite(leg.maxAdversePercent)) {
+                              detailText = `미도달 · 최대 괴리 ${leg.maxAdversePercent.toFixed(1)}%`;
                             }
-                          )}
-                          {!targetAnalysis.buyLegs.length &&
-                            !targetAnalysis.sellLegs.length && (
-                              <tr>
-                                <td
-                                  colSpan={6}
-                                  className="px-3 py-3 text-center text-gray-400"
-                                >
-                                  분석할 전략 목표가가 없습니다.
+
+                            return (
+                              <tr key={`${leg.type}-${leg.id}`} className="border-b border-gray-700">
+                                <td className="px-3 py-2 text-gray-300">
+                                  {leg.type === "buy" ? "매수" : "매도"}
                                 </td>
+                                <td className="px-3 py-2">{leg.sequence}차</td>
+                                <td className="px-3 py-2 text-right text-white">
+                                  {formatTargetPrice(leg.targetPrice, leg.rawTargetPrice)}
+                                </td>
+                                <td className="px-3 py-2 text-gray-300">
+                                  {formatDate(leg.createdAt ?? leg.startDate)}
+                                </td>
+                                <td className="px-3 py-2 text-gray-200">{statusText}</td>
+                                <td className="px-3 py-2 text-gray-400">{detailText}</td>
                               </tr>
-                            )}
+                            );
+                          })}
                         </tbody>
                       </table>
-                    </div>
-
-                    <div className="grid gap-4 md:grid-cols-2">
-                      <div className="bg-gray-900 rounded-lg p-4">
-                        <h4 className="text-sm font-semibold text-gray-200 mb-3">
-                          목표 도달까지 걸린 기간 (일)
-                        </h4>
-                        {targetAnalysis.reachedLegs.length ? (
-                          <ul className="space-y-2">
-                            {(() => {
-                              const maxDays = Math.max(
-                                ...targetAnalysis.reachedLegs.map((leg) => leg.daysToHit || 0)
-                              );
-                              return targetAnalysis.reachedLegs.map((leg) => {
-                                const width = maxDays
-                                  ? Math.round((leg.daysToHit / maxDays) * 100)
-                                  : 0;
-                                return (
-                                  <li key={`${leg.type}-days-${leg.id}`}>
-                                    <div className="flex justify-between text-xs text-gray-400 mb-1">
-                                      <span>
-                                        {leg.type === "buy" ? "매수" : "매도"} {leg.sequence}차
-                                      </span>
-                                      <span>{leg.daysToHit}일</span>
-                                    </div>
-                                    <div className="w-full bg-gray-800 h-2 rounded">
-                                      <div
-                                        className="bg-teal-400 h-2 rounded"
-                                        style={{ width: `${width}%` }}
-                                      />
-                                    </div>
-                                  </li>
-                                );
-                              });
-                            })()}
-                          </ul>
-                        ) : (
-                          <p className="text-sm text-gray-400">
-                            목표가에 도달한 구간이 없습니다.
-                          </p>
-                        )}
-                      </div>
-
-                      <div className="bg-gray-900 rounded-lg p-4">
-                        <h4 className="text-sm font-semibold text-gray-200 mb-3">
-                          미도달 시 최대 손실 폭 (%)
-                        </h4>
-                        {targetAnalysis.unreachedLegs.length ? (
-                          <ul className="space-y-2">
-                            {(() => {
-                              const maxLoss = Math.max(
-                                ...targetAnalysis.unreachedLegs.map(
-                                  (leg) => leg.maxAdversePercent || 0
-                                )
-                              );
-                              return targetAnalysis.unreachedLegs.map((leg) => {
-                                const width = maxLoss
-                                  ? Math.round(
-                                      (leg.maxAdversePercent / maxLoss) * 100
-                                    )
-                                  : 0;
-                                return (
-                                  <li key={`${leg.type}-loss-${leg.id}`}>
-                                    <div className="flex justify-between text-xs text-gray-400 mb-1">
-                                      <span>
-                                        {leg.type === "buy" ? "매수" : "매도"} {leg.sequence}차
-                                      </span>
-                                      <span>{leg.maxAdversePercent.toFixed(1)}%</span>
-                                    </div>
-                                    <div className="w-full bg-gray-800 h-2 rounded">
-                                      <div
-                                        className="bg-orange-400 h-2 rounded"
-                                        style={{ width: `${width}%` }}
-                                      />
-                                    </div>
-                                  </li>
-                                );
-                              });
-                            })()}
-                          </ul>
-                        ) : (
-                          <p className="text-sm text-gray-400">
-                            미도달한 목표가에 대한 손실 데이터가 없습니다.
-                          </p>
-                        )}
-                      </div>
                     </div>
                   </div>
                 ) : (
                   <p className="text-sm text-gray-400">
-                    가격 데이터가 부족해 백테스트를 수행할 수 없습니다.
+                    아직 가격 추적 정보가 없어 실행 여부를 계산할 수 없습니다.
                   </p>
                 )}
               </div>
 
               <div>
                 <h3 className="text-gray-300 font-semibold mb-2">최근 종가 추이</h3>
-                {priceLoading ? (
-                  <p className="text-sm text-gray-400">주가 데이터를 불러오는 중입니다...</p>
-                ) : priceError ? (
-                  <p className="text-sm text-red-400">
-                    주가 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
-                  </p>
-                ) : recentPrices.length ? (
+                {recentPrices.length ? (
                   <ul className="grid gap-2 sm:grid-cols-2 text-sm">
                     {recentPrices.map((item) => {
                       const numericClose = Number(item.close);

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 1800,
+  },
 })


### PR DESCRIPTION
## Summary
- replace the target price backtest widget with an execution summary that uses each leg's filled status and timestamps
- analyze leg price data from the stock document itself so each leg's start date filters the relevant prices and days-to-hit metrics
- raise Vite's chunk size warning limit to keep the production build clean after the UI changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d99dde608323aa70ecbfa07e5b6d