### PR TITLE
Fix causal inference API endpoint and configuration

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,5 +1,8 @@
 // START OF FILE src/lib/api.js
 
+import { resolveApiBase } from "./apiConfig";
+export { resolveApiBase } from "./apiConfig";
+
 const DEFAULT_TIMEOUT = 12000;
 
 export class ApiError extends Error {
@@ -11,11 +14,22 @@ export class ApiError extends Error {
   }
 }
 
-function buildUrl(path = "") {
-  const base = import.meta.env.VITE_API_BASE || "";
-  const trimmedBase = base.replace(/\/$/, "");
+function buildUrl(path = "", { ensureApiPrefix = false } = {}) {
+  const base = resolveApiBase() || "";
   const trimmedPath = path.replace(/^\//, "");
-  return `${trimmedBase}/${trimmedPath}`.replace(/\/\/+/, "/");
+
+  let normalizedBase = base.replace(/\/$/, "");
+
+  if (ensureApiPrefix) {
+    if (!normalizedBase) {
+      normalizedBase = "/api";
+    } else if (!normalizedBase.endsWith("/api")) {
+      normalizedBase = `${normalizedBase}/api`;
+    }
+  }
+
+  const combined = normalizedBase ? `${normalizedBase}/${trimmedPath}` : `/${trimmedPath}`;
+  return combined.replace(/\/\/+/, "/");
 }
 
 export async function fetchWithTimeout(url, { method = "GET", headers = {}, body, timeout = DEFAULT_TIMEOUT, signal } = {}) {
@@ -99,11 +113,7 @@ function composeAbortSignal(...signals) {
 }
 
 export async function inferCausalPaths(payload, options = {}) {
-  if (!import.meta.env.VITE_API_BASE) {
-    throw new ApiError("API 기본 URL(VITE_API_BASE)이 설정되지 않았습니다.");
-  }
-
-  const url = buildUrl("/infer");
+  const url = buildUrl("infer-paths", { ensureApiPrefix: true });
   const body = JSON.stringify(payload);
 
   return fetchWithTimeout(url, {

--- a/src/pages/CausalInference.jsx
+++ b/src/pages/CausalInference.jsx
@@ -5,7 +5,7 @@ import { Helmet } from "react-helmet";
 import CausalForm from "../components/CausalForm";
 import PathList from "../components/PathList";
 import CausalGraph from "../components/CausalGraph";
-import { inferCausalPaths, ApiError } from "../lib/api";
+import { inferCausalPaths, ApiError, resolveApiBase } from "../lib/api";
 import { formatPercent, formatScore, formatDirectionLabel } from "../lib/format";
 import { buildSampleCausalResponse } from "../data/sampleCausalResponse";
 
@@ -32,8 +32,8 @@ export default function CausalInference() {
   const [isUsingSampleData, setIsUsingSampleData] = useState(false);
   const [sampleNotice, setSampleNotice] = useState("");
 
-  const apiBase = import.meta.env.VITE_API_BASE;
-  const isApiConfigured = Boolean(apiBase);
+  const apiBase = resolveApiBase();
+  const isApiConfigured = typeof apiBase === "string" && apiBase.length > 0;
 
   const applySampleData = (payload = {}, notice) => {
     const sampleResponse = buildSampleCausalResponse({


### PR DESCRIPTION
## Summary
- normalize API base resolution to honor both VITE_API_BASE and VITE_API_BASE_URL and default to the Netlify proxy path
- update causal inference requests to target the /api/infer-paths backend endpoint and share the resolved base URL
- ensure the causal inference page detects the configured API base via the shared resolver

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ea63ae1c8323888c9b3c0f408d3e