### PR TITLE
Fix sample causal graph JSON import

### DIFF
--- a/src/data/sampleCausalResponse.js
+++ b/src/data/sampleCausalResponse.js
@@ -1,4 +1,4 @@
-import causalGraph from "./causal_graph.json" with { type: "json" };
+import causalGraph from "./causal_graph.json";
 
 const PATH_SEQUENCES = [
   {


### PR DESCRIPTION
## Summary
- update the sample causal response helper to use a standard JSON import so the bundle can load causal_graph.json correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ee9d83108323a1a8bb6c2b34c5fa