### PR TITLE
Add Netlify crawler for Naver popular stocks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,13 @@
   headers = {Access-Control-Allow-Origin = "*"}
 
 [[redirects]]
+  from = "/api/popular-stocks"
+  to = "/.netlify/functions/popular-stocks"
+  status = 200
+  force = true
+  headers = {Access-Control-Allow-Origin = "*"}
+
+[[redirects]]
   from = "/api/*"
   to = "https://stock-lab-backend-repo.onrender.com/api/:splat"
   status = 200

--- a/netlify/functions/popular-stocks.js
+++ b/netlify/functions/popular-stocks.js
@@ -1,0 +1,158 @@
+const TARGET_URL = "https://finance.naver.com/sise/lastsearch2.naver";
+
+const stripTags = (html) => {
+  if (typeof html !== "string") {
+    return "";
+  }
+
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&#039;/gi, "'")
+    .replace(/&quot;/gi, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const extractCode = (html) => {
+  if (typeof html !== "string") {
+    return "";
+  }
+
+  const match = html.match(/code=([0-9A-Z]+)/i);
+  return match ? match[1] : "";
+};
+
+const parseRows = (html) => {
+  if (typeof html !== "string" || !html) {
+    return [];
+  }
+
+  const rows = [];
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch;
+
+  while ((rowMatch = rowRegex.exec(html))) {
+    const rowHtml = rowMatch[1];
+    if (!rowHtml || !/class\s*=\s*"[^"]*\bno\b/i.test(rowHtml)) {
+      continue;
+    }
+
+    const cellMatches = [...rowHtml.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)];
+    if (cellMatches.length < 10) {
+      continue;
+    }
+
+    const rankText = stripTags(cellMatches[0][1]);
+    const rank = Number.parseInt(rankText, 10);
+
+    if (!Number.isFinite(rank)) {
+      continue;
+    }
+
+    const nameCellHtml = cellMatches[1][1];
+    const name = stripTags(nameCellHtml);
+    const code = extractCode(nameCellHtml);
+
+    rows.push({
+      rank,
+      name,
+      code,
+      searchRatio: stripTags(cellMatches[2][1]),
+      price: stripTags(cellMatches[3][1]),
+      change: stripTags(cellMatches[4][1]),
+      rate: stripTags(cellMatches[5][1]),
+      volume: stripTags(cellMatches[6][1]),
+      open: stripTags(cellMatches[7][1]),
+      high: stripTags(cellMatches[8][1]),
+      low: stripTags(cellMatches[9][1]),
+    });
+  }
+
+  return rows
+    .filter((row) => Number.isFinite(row.rank))
+    .sort((a, b) => a.rank - b.rank)
+    .slice(0, 30);
+};
+
+const createResponse = (statusCode, payload, extraHeaders = {}) => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json; charset=utf-8",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": statusCode === 200 ? "public, max-age=120" : "no-store",
+    ...extraHeaders,
+  },
+  body: JSON.stringify(payload),
+});
+
+export const handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET,OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization",
+        "Access-Control-Max-Age": "3600",
+      },
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return createResponse(405, { error: "Method Not Allowed" }, { Allow: "GET,OPTIONS" });
+  }
+
+  try {
+    const upstreamResponse = await fetch(TARGET_URL, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+      },
+    });
+
+    if (!upstreamResponse.ok) {
+      return createResponse(upstreamResponse.status, {
+        error: "네이버 금융 페이지를 불러오는 데 실패했습니다.",
+        details: {
+          status: upstreamResponse.status,
+        },
+      });
+    }
+
+    const rawHtml = await upstreamResponse.text();
+    const items = parseRows(rawHtml);
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return createResponse(502, {
+        error: "인기 종목 데이터를 파싱하지 못했습니다.",
+      });
+    }
+
+    const now = new Date();
+    const asOf = now.toISOString();
+    const asOfLabel = new Intl.DateTimeFormat("ko-KR", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: "Asia/Seoul",
+    }).format(now);
+
+    return createResponse(200, {
+      asOf,
+      asOfLabel,
+      items,
+      source: TARGET_URL,
+    });
+  } catch (error) {
+    console.error("[popular-stocks] Unexpected error", error);
+    return createResponse(500, {
+      error: "인기 종목 데이터를 불러오는 중 오류가 발생했습니다.",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+export default handler;

--- a/src/components/PopularStocksCompact.jsx
+++ b/src/components/PopularStocksCompact.jsx
@@ -4,6 +4,8 @@ import { Link } from "react-router-dom"; // Link 컴포넌트 임포트 추가
 export default function PopularStocksCompact() {
   const [stocks, setStocks] = useState([]);
   const [updatedAt, setUpdatedAt] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
     // `popular.json` 파일이 `src/data` 폴더에 있다고 가정합니다.
@@ -21,6 +23,35 @@ export default function PopularStocksCompact() {
       });
   }, []);
 
+  const fetchPopularStocks = async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+
+    try {
+      const response = await fetch("/.netlify/functions/popular-stocks");
+
+      if (!response.ok) {
+        throw new Error("인기 종목 정보를 불러오지 못했습니다.");
+      }
+
+      const payload = await response.json();
+
+      if (!payload || !Array.isArray(payload.items)) {
+        throw new Error("예상치 못한 응답 형식입니다.");
+      }
+
+      setStocks(payload.items);
+      setUpdatedAt(payload.asOfLabel || payload.asOf || "");
+    } catch (error) {
+      console.error("[PopularStocksCompact] popular-stocks fetch failed", error);
+      setErrorMessage(
+        error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다."
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <section className="mb-12 p-6 bg-gray-800 rounded-lg shadow-xl">
       <h2 className="text-2xl font-semibold mb-6 text-white border-b-2 border-orange-500 pb-2">
@@ -28,26 +59,65 @@ export default function PopularStocksCompact() {
         {updatedAt && <span className="text-sm text-gray-400 ml-3">(기준: {updatedAt})</span>}
       </h2>
 
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+        <p className="text-sm text-gray-400">
+          네이버 금융 검색 상위 30개 종목을 실시간으로 불러옵니다.
+        </p>
+        <button
+          type="button"
+          onClick={fetchPopularStocks}
+          disabled={isLoading}
+          className="bg-orange-500 hover:bg-orange-400 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-2 px-4 rounded-md transition duration-300"
+        >
+          {isLoading ? "불러오는 중..." : "인기종목 불러오기"}
+        </button>
+      </div>
+
+      {errorMessage && (
+        <div className="mb-4 p-3 rounded-md bg-red-500/10 border border-red-500/40 text-red-300 text-sm">
+          {errorMessage}
+        </div>
+      )}
+
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {stocks.length === 0 && (
+          <p className="text-gray-400 text-sm col-span-full">
+            표시할 데이터가 없습니다. 상단의 버튼을 눌러 최신 인기 종목을 불러와 보세요.
+          </p>
+        )}
         {stocks.map((stock) => {
           // stock.rate 값에 따라 텍스트 색상 결정
-          const isPositive = stock.rate && stock.rate.startsWith('+');
-          const isNegative = stock.rate && stock.rate.startsWith('-');
+          const trimmedRate = typeof stock.rate === "string" ? stock.rate.trim() : "";
+          const isPositive = trimmedRate.startsWith("+");
+          const isNegative = trimmedRate.startsWith("-");
           const textColorClass = isPositive ? 'text-green-500' : isNegative ? 'text-red-500' : 'text-gray-300';
+          const changeColorClass = isPositive ? 'text-green-400' : isNegative ? 'text-red-400' : 'text-gray-300';
+          const cardKey = stock.code || `${stock.rank}-${stock.name}`;
 
           return (
             <div
-              key={stock.code}
+              key={cardKey}
               className="bg-gray-700 p-3 rounded-md shadow-md flex flex-col justify-between hover:bg-gray-600 transition duration-300"
             >
               <div className="flex items-baseline mb-1">
                 <span className="text-gray-400 text-sm mr-2">{stock.rank}.</span>
                 <h3 className="text-white text-lg font-medium">{stock.name}</h3>
-                <p className="text-gray-400 text-sm ml-2">({stock.code})</p>
+                {stock.code && <p className="text-gray-400 text-sm ml-2">({stock.code})</p>}
               </div>
-              <div className="flex justify-between items-center text-sm">
-                <p className="text-gray-300">현재가: {stock.price}</p>
-                <p className={`font-semibold ${textColorClass}`}>{stock.rate}</p>
+              <div className="space-y-1 text-sm">
+                {stock.searchRatio && (
+                  <p className="text-gray-300">검색비율: {stock.searchRatio}</p>
+                )}
+                <p className="text-gray-300">현재가: {stock.price || "-"}</p>
+                {stock.change && (
+                  <p className={`${changeColorClass}`}>전일비: {stock.change}</p>
+                )}
+                <p className={`font-semibold ${textColorClass}`}>
+                  등락률: {stock.rate || "-"}
+                </p>
+                {stock.volume && (
+                  <p className="text-gray-400">거래량: {stock.volume}</p>
+                )}
               </div>
               {/* 각 종목 클릭 시 상세 페이지로 이동하도록 Link를 추가할 수도 있습니다. */}
               {/* <Link to={`/stock/${stock.code}`} className="text-blue-400 hover:text-blue-300 text-sm mt-2">


### PR DESCRIPTION
## Summary
- add a Netlify serverless function that scrapes Naver Finance popular stock rankings and returns normalized JSON
- wire the popular stocks widget to trigger the crawler via a new button with loading and error handling
- route /api/popular-stocks through Netlify so deployments can reach the new function

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5223e8eb083239aca01ce8d375345