### PR TITLE
Add foreign and institution net buy history pages

### DIFF
--- a/netlify/functions/foreign-net-buy.js
+++ b/netlify/functions/foreign-net-buy.js
@@ -1,0 +1,210 @@
+import { TextDecoder } from "node:util";
+
+const TARGET_URL = "https://finance.naver.com/sise/sise_deal_rank.naver?investor_gubun=9000&type=buy";
+const eucKrDecoder = new TextDecoder("euc-kr");
+
+const stripTags = (html) => {
+  if (typeof html !== "string") {
+    return "";
+  }
+
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&#039;/gi, "'")
+    .replace(/&quot;/gi, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const extractCode = (html) => {
+  if (typeof html !== "string") {
+    return "";
+  }
+
+  const match = html.match(/code=([0-9A-Z]+)/i);
+  return match ? match[1] : "";
+};
+
+const normalizeDateLabel = (rawDate) => {
+  const trimmed = typeof rawDate === "string" ? rawDate.trim() : "";
+
+  const match = trimmed.match(/(\d{2})[./-](\d{2})[./-](\d{2})/);
+  if (!match) {
+    return {
+      asOf: trimmed,
+      asOfLabel: trimmed,
+      sortValue: Number.NEGATIVE_INFINITY,
+    };
+  }
+
+  const [, yy, mm, dd] = match;
+  const year = 2000 + Number.parseInt(yy, 10);
+  const month = mm.padStart(2, "0");
+  const day = dd.padStart(2, "0");
+
+  const isoDate = `${year}-${month}-${day}`;
+  const sortValue = Date.parse(`${isoDate}T00:00:00+09:00`);
+
+  return {
+    asOf: isoDate,
+    asOfLabel: `${year}년 ${month}월 ${day}일`,
+    sortValue: Number.isFinite(sortValue) ? sortValue : Number.NEGATIVE_INFINITY,
+  };
+};
+
+const parseSectionRows = (tableHtml) => {
+  if (typeof tableHtml !== "string" || !tableHtml) {
+    return [];
+  }
+
+  const rows = [];
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch;
+
+  while ((rowMatch = rowRegex.exec(tableHtml))) {
+    const rowContent = rowMatch[1];
+
+    if (!rowContent || /<th/i.test(rowContent) || /colspan/gi.test(rowContent)) {
+      continue;
+    }
+
+    const cellMatches = [...rowContent.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)];
+    if (cellMatches.length < 4) {
+      continue;
+    }
+
+    const nameCell = cellMatches[0][1];
+    const name = stripTags(nameCell);
+    if (!name) {
+      continue;
+    }
+
+    rows.push({
+      name,
+      code: extractCode(nameCell),
+      quantity: stripTags(cellMatches[1][1]),
+      amount: stripTags(cellMatches[2][1]),
+      tradingVolume: stripTags(cellMatches[3][1]),
+    });
+  }
+
+  return rows.map((row, index) => ({ ...row, rank: index + 1 })).slice(0, 30);
+};
+
+const parseSections = (html) => {
+  if (typeof html !== "string" || !html) {
+    return [];
+  }
+
+  const sections = [];
+  const sectionRegex = /<div class="box_type_ms"[^>]*>([\s\S]*?)(?=<div class="box_type_ms"|<div class="c">|$)/gi;
+  let match;
+
+  while ((match = sectionRegex.exec(html))) {
+    const sectionHtml = match[1];
+    if (!sectionHtml) continue;
+
+    const dateMatch = sectionHtml.match(/<div class="sise_guide_date">([^<]*)<\/div>/i);
+    const { asOf, asOfLabel, sortValue } = normalizeDateLabel(dateMatch ? dateMatch[1] : "");
+
+    const tableMatch = sectionHtml.match(/<table[^>]*summary="[^"]*순매수[^"]*"[\s\S]*?<\/table>/i);
+    const tableHtml = tableMatch ? tableMatch[0] : "";
+    const items = parseSectionRows(tableHtml);
+
+    if (items.length === 0) {
+      continue;
+    }
+
+    sections.push({ asOf, asOfLabel, items, sortValue });
+  }
+
+  return sections
+    .sort((a, b) => (b.sortValue || 0) - (a.sortValue || 0))
+    .map(({ sortValue, ...rest }) => rest);
+};
+
+const createResponse = (statusCode, payload, extraHeaders = {}) => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json; charset=utf-8",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": statusCode === 200 ? "public, max-age=120" : "no-store",
+    ...extraHeaders,
+  },
+  body: JSON.stringify(payload),
+});
+
+export const handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET,OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization",
+        "Access-Control-Max-Age": "3600",
+      },
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return createResponse(405, { error: "Method Not Allowed" }, { Allow: "GET,OPTIONS" });
+  }
+
+  try {
+    const upstreamResponse = await fetch(TARGET_URL, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+      },
+    });
+
+    if (!upstreamResponse.ok) {
+      return createResponse(upstreamResponse.status, {
+        error: "네이버 금융 페이지를 불러오는 데 실패했습니다.",
+        details: { status: upstreamResponse.status },
+      });
+    }
+
+    const rawBuffer = Buffer.from(await upstreamResponse.arrayBuffer());
+    let decodedHtml;
+
+    try {
+      decodedHtml = eucKrDecoder.decode(rawBuffer);
+    } catch (decodeError) {
+      console.warn("[foreign-net-buy] EUC-KR decoding failed, falling back to UTF-8", decodeError);
+      decodedHtml = rawBuffer.toString("utf-8");
+    }
+
+    const snapshots = parseSections(decodedHtml);
+
+    if (!Array.isArray(snapshots) || snapshots.length === 0) {
+      return createResponse(502, {
+        error: "외국인 순매수 데이터를 파싱하지 못했습니다.",
+      });
+    }
+
+    const latest = snapshots[0];
+
+    return createResponse(200, {
+      asOf: latest.asOf,
+      asOfLabel: latest.asOfLabel,
+      items: latest.items,
+      latest,
+      snapshots,
+      source: TARGET_URL,
+    });
+  } catch (error) {
+    console.error("[foreign-net-buy] Unexpected error", error);
+    return createResponse(500, {
+      error: "외국인 순매수 데이터를 불러오는 중 오류가 발생했습니다.",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+export default handler;

--- a/netlify/functions/institution-net-buy.js
+++ b/netlify/functions/institution-net-buy.js
@@ -1,0 +1,210 @@
+import { TextDecoder } from "node:util";
+
+const TARGET_URL = "https://finance.naver.com/sise/sise_deal_rank.naver?investor_gubun=1000&type=buy";
+const eucKrDecoder = new TextDecoder("euc-kr");
+
+const stripTags = (html) => {
+  if (typeof html !== "string") {
+    return "";
+  }
+
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&#039;/gi, "'")
+    .replace(/&quot;/gi, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const extractCode = (html) => {
+  if (typeof html !== "string") {
+    return "";
+  }
+
+  const match = html.match(/code=([0-9A-Z]+)/i);
+  return match ? match[1] : "";
+};
+
+const normalizeDateLabel = (rawDate) => {
+  const trimmed = typeof rawDate === "string" ? rawDate.trim() : "";
+
+  const match = trimmed.match(/(\d{2})[./-](\d{2})[./-](\d{2})/);
+  if (!match) {
+    return {
+      asOf: trimmed,
+      asOfLabel: trimmed,
+      sortValue: Number.NEGATIVE_INFINITY,
+    };
+  }
+
+  const [, yy, mm, dd] = match;
+  const year = 2000 + Number.parseInt(yy, 10);
+  const month = mm.padStart(2, "0");
+  const day = dd.padStart(2, "0");
+
+  const isoDate = `${year}-${month}-${day}`;
+  const sortValue = Date.parse(`${isoDate}T00:00:00+09:00`);
+
+  return {
+    asOf: isoDate,
+    asOfLabel: `${year}년 ${month}월 ${day}일`,
+    sortValue: Number.isFinite(sortValue) ? sortValue : Number.NEGATIVE_INFINITY,
+  };
+};
+
+const parseSectionRows = (tableHtml) => {
+  if (typeof tableHtml !== "string" || !tableHtml) {
+    return [];
+  }
+
+  const rows = [];
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch;
+
+  while ((rowMatch = rowRegex.exec(tableHtml))) {
+    const rowContent = rowMatch[1];
+
+    if (!rowContent || /<th/i.test(rowContent) || /colspan/gi.test(rowContent)) {
+      continue;
+    }
+
+    const cellMatches = [...rowContent.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)];
+    if (cellMatches.length < 4) {
+      continue;
+    }
+
+    const nameCell = cellMatches[0][1];
+    const name = stripTags(nameCell);
+    if (!name) {
+      continue;
+    }
+
+    rows.push({
+      name,
+      code: extractCode(nameCell),
+      quantity: stripTags(cellMatches[1][1]),
+      amount: stripTags(cellMatches[2][1]),
+      tradingVolume: stripTags(cellMatches[3][1]),
+    });
+  }
+
+  return rows.map((row, index) => ({ ...row, rank: index + 1 })).slice(0, 30);
+};
+
+const parseSections = (html) => {
+  if (typeof html !== "string" || !html) {
+    return [];
+  }
+
+  const sections = [];
+  const sectionRegex = /<div class="box_type_ms"[^>]*>([\s\S]*?)(?=<div class="box_type_ms"|<div class="c">|$)/gi;
+  let match;
+
+  while ((match = sectionRegex.exec(html))) {
+    const sectionHtml = match[1];
+    if (!sectionHtml) continue;
+
+    const dateMatch = sectionHtml.match(/<div class="sise_guide_date">([^<]*)<\/div>/i);
+    const { asOf, asOfLabel, sortValue } = normalizeDateLabel(dateMatch ? dateMatch[1] : "");
+
+    const tableMatch = sectionHtml.match(/<table[^>]*summary="[^"]*순매수[^"]*"[\s\S]*?<\/table>/i);
+    const tableHtml = tableMatch ? tableMatch[0] : "";
+    const items = parseSectionRows(tableHtml);
+
+    if (items.length === 0) {
+      continue;
+    }
+
+    sections.push({ asOf, asOfLabel, items, sortValue });
+  }
+
+  return sections
+    .sort((a, b) => (b.sortValue || 0) - (a.sortValue || 0))
+    .map(({ sortValue, ...rest }) => rest);
+};
+
+const createResponse = (statusCode, payload, extraHeaders = {}) => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json; charset=utf-8",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": statusCode === 200 ? "public, max-age=120" : "no-store",
+    ...extraHeaders,
+  },
+  body: JSON.stringify(payload),
+});
+
+export const handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET,OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization",
+        "Access-Control-Max-Age": "3600",
+      },
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return createResponse(405, { error: "Method Not Allowed" }, { Allow: "GET,OPTIONS" });
+  }
+
+  try {
+    const upstreamResponse = await fetch(TARGET_URL, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+      },
+    });
+
+    if (!upstreamResponse.ok) {
+      return createResponse(upstreamResponse.status, {
+        error: "네이버 금융 페이지를 불러오는 데 실패했습니다.",
+        details: { status: upstreamResponse.status },
+      });
+    }
+
+    const rawBuffer = Buffer.from(await upstreamResponse.arrayBuffer());
+    let decodedHtml;
+
+    try {
+      decodedHtml = eucKrDecoder.decode(rawBuffer);
+    } catch (decodeError) {
+      console.warn("[institution-net-buy] EUC-KR decoding failed, falling back to UTF-8", decodeError);
+      decodedHtml = rawBuffer.toString("utf-8");
+    }
+
+    const snapshots = parseSections(decodedHtml);
+
+    if (!Array.isArray(snapshots) || snapshots.length === 0) {
+      return createResponse(502, {
+        error: "기관 순매수 데이터를 파싱하지 못했습니다.",
+      });
+    }
+
+    const latest = snapshots[0];
+
+    return createResponse(200, {
+      asOf: latest.asOf,
+      asOfLabel: latest.asOfLabel,
+      items: latest.items,
+      latest,
+      snapshots,
+      source: TARGET_URL,
+    });
+  } catch (error) {
+    console.error("[institution-net-buy] Unexpected error", error);
+    return createResponse(500, {
+      error: "기관 순매수 데이터를 불러오는 중 오류가 발생했습니다.",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+export default handler;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,8 @@ import AiSummaryDetailPage from "./AiSummaryDetailPage";
 import PortfolioPage from "./PortfolioPage";
 import CausalInference from "./pages/CausalInference";
 import PopularStocksHistory from "./pages/PopularStocksHistory";
+import ForeignNetBuyHistory from "./pages/ForeignNetBuyHistory";
+import InstitutionNetBuyHistory from "./pages/InstitutionNetBuyHistory";
 import AdminLayout from "./admin/AdminLayout";
 import AdminDashboard from "./admin/sections/AdminDashboard";
 import BlogManager from "./admin/sections/BlogManager";
@@ -47,6 +49,8 @@ function App() {
       <Route path="/causal" element={<CausalInference />} />
       <Route path="/portfolio" element={<PortfolioPage />} />
       <Route path="/popular-history" element={<PopularStocksHistory />} />
+      <Route path="/foreign-net-buy-history" element={<ForeignNetBuyHistory />} />
+      <Route path="/institution-net-buy-history" element={<InstitutionNetBuyHistory />} />
 
       {/* AI 시장 이슈 요약 관련 라우트 */}
       <Route path="/ai-summaries" element={<AiSummaryListPage />} />

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useLocation, Link } from "react-router-dom";
 import PopularStocksCompact from "./components/PopularStocksCompact";
+import { ForeignNetBuySection, InstitutionNetBuySection } from "./components/InvestorNetBuySection";
 import { Helmet } from "react-helmet";
 import { API_BASE_URL } from "./lib/apiConfig";
 
@@ -302,6 +303,8 @@ export default function Home() {
               <li><Link to="/forum" className="text-gray-300 hover:text-white transition duration-300">종목상담</Link></li>
               <li><Link to="/causal" className="text-gray-300 hover:text-white transition duration-300">연쇄효과 추론</Link></li>
               <li><Link to="/popular-history" className="text-gray-300 hover:text-white transition duration-300">인기종목 히스토리</Link></li>
+              <li><a href="#foreign-net-buy" className="text-gray-300 hover:text-white transition duration-300">외국인 순매수</a></li>
+              <li><a href="#institution-net-buy" className="text-gray-300 hover:text-white transition duration-300">기관 순매수</a></li>
               <li><a href="#social-media" className="text-gray-300 hover:text-white transition duration-300">미디어</a></li>
               <li><a href="#extra-features" className="text-gray-300 hover:text-white transition duration-300">부가기능</a></li>
             </ul>
@@ -599,6 +602,8 @@ export default function Home() {
         </section>
 
         <PopularStocksCompact />
+        <ForeignNetBuySection />
+        <InstitutionNetBuySection />
 
       </main>
 

--- a/src/components/PopularStocksCompact.jsx
+++ b/src/components/PopularStocksCompact.jsx
@@ -10,51 +10,11 @@ import {
   serverTimestamp,
   setDoc,
 } from "firebase/firestore";
+import {
+  buildSnapshotSignature,
+} from "../lib/snapshotUtils";
 
 const SNAPSHOT_COOLDOWN_MS = 60 * 60 * 1000; // 60분
-
-const normalizeItemForComparison = (item) => {
-  if (!item || typeof item !== "object") {
-    return {};
-  }
-
-  return Object.keys(item)
-    .sort()
-    .reduce((acc, key) => {
-      acc[key] = item[key];
-      return acc;
-    }, {});
-};
-
-const normalizeItemsForComparison = (items) => {
-  if (!Array.isArray(items)) {
-    return [];
-  }
-
-  return [...items]
-    .sort((a, b) => {
-      const rankA = typeof a?.rank === "number" ? a.rank : parseFloat(a?.rank) || Number.MAX_SAFE_INTEGER;
-      const rankB = typeof b?.rank === "number" ? b.rank : parseFloat(b?.rank) || Number.MAX_SAFE_INTEGER;
-
-      if (rankA !== rankB) {
-        return rankA - rankB;
-      }
-
-      const nameA = String(a?.name ?? "");
-      const nameB = String(b?.name ?? "");
-      return nameA.localeCompare(nameB, "ko-KR");
-    })
-    .map(normalizeItemForComparison);
-};
-
-const buildSnapshotSignature = (asOfValue, items) => {
-  const normalizedAsOf = typeof asOfValue === "string" ? asOfValue : String(asOfValue ?? "");
-  const normalizedItems = normalizeItemsForComparison(items);
-  return JSON.stringify({
-    asOf: normalizedAsOf,
-    items: normalizedItems,
-  });
-};
 
 export default function PopularStocksCompact() {
   const [stocks, setStocks] = useState([]);

--- a/src/data/foreignNetBuy.json
+++ b/src/data/foreignNetBuy.json
@@ -1,0 +1,46 @@
+{
+  "asOf": "2025-10-02",
+  "asOfLabel": "2025년 10월 2일",
+  "items": [
+    {
+      "rank": 1,
+      "name": "삼성전자",
+      "code": "005930",
+      "quantity": "19,178",
+      "amount": "1,720,023",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 2,
+      "name": "SK하이닉스",
+      "code": "000660",
+      "quantity": "1,039",
+      "amount": "408,998",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 3,
+      "name": "삼성전자우",
+      "code": "005935",
+      "quantity": "1,866",
+      "amount": "130,657",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 4,
+      "name": "현대차",
+      "code": "005380",
+      "quantity": "393",
+      "amount": "86,574",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 5,
+      "name": "기아",
+      "code": "000270",
+      "quantity": "669",
+      "amount": "69,389",
+      "tradingVolume": "-"
+    }
+  ]
+}

--- a/src/data/institutionNetBuy.json
+++ b/src/data/institutionNetBuy.json
@@ -1,0 +1,46 @@
+{
+  "asOf": "2025-10-02",
+  "asOfLabel": "2025년 10월 2일",
+  "items": [
+    {
+      "rank": 1,
+      "name": "KODEX 레버리지",
+      "code": "122630",
+      "quantity": "3,237",
+      "amount": "104,695",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 2,
+      "name": "삼성전자우",
+      "code": "005935",
+      "quantity": "1,125",
+      "amount": "78,794",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 3,
+      "name": "SK스퀘어",
+      "code": "402340",
+      "quantity": "309",
+      "amount": "74,785",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 4,
+      "name": "KODEX 200",
+      "code": "069500",
+      "quantity": "1,182",
+      "amount": "58,693",
+      "tradingVolume": "-"
+    },
+    {
+      "rank": 5,
+      "name": "LG에너지솔루션",
+      "code": "373220",
+      "quantity": "139",
+      "amount": "55,357",
+      "tradingVolume": "-"
+    }
+  ]
+}

--- a/src/lib/historyUtils.js
+++ b/src/lib/historyUtils.js
@@ -1,0 +1,236 @@
+import { normalizeItemForComparison } from "./snapshotUtils";
+
+export const formatTimestamp = (value) => {
+  if (!value) return "-";
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toLocaleString("ko-KR");
+  }
+
+  if (typeof value?.toDate === "function") {
+    try {
+      return value.toDate().toLocaleString("ko-KR");
+    } catch (error) {
+      console.error("[historyUtils] Timestamp 변환 실패", error);
+    }
+  }
+
+  if (typeof value?.seconds === "number") {
+    return new Date(value.seconds * 1000).toLocaleString("ko-KR");
+  }
+
+  return String(value);
+};
+
+export const toDateInstance = (value) => {
+  if (!value) return null;
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "string") {
+    const direct = new Date(value);
+    if (!Number.isNaN(direct.getTime())) {
+      return direct;
+    }
+
+    const normalized = value
+      .replace(/년|월/g, "-")
+      .replace(/일/g, "")
+      .replace(/[./]/g, "-")
+      .trim();
+
+    if (normalized) {
+      const isoCandidate = normalized.includes("T")
+        ? normalized
+        : normalized.replace(/\s+/, "T");
+      const fallback = new Date(isoCandidate);
+      if (!Number.isNaN(fallback.getTime())) {
+        return fallback;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof value?.toDate === "function") {
+    try {
+      return value.toDate();
+    } catch (error) {
+      console.error("[historyUtils] toDate 변환 실패", error);
+    }
+  }
+
+  if (typeof value?.seconds === "number") {
+    return new Date(value.seconds * 1000);
+  }
+
+  return null;
+};
+
+export const toLocalDateKey = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const formatDateHeading = (dateKey) => {
+  if (!dateKey || dateKey === "날짜 미상") {
+    return "날짜 미상";
+  }
+
+  const [year, month, day] = dateKey.split("-");
+
+  if (!year || !month || !day) {
+    return dateKey;
+  }
+
+  return `${year}년 ${month}월 ${day}일`;
+};
+
+const getItemIdentifier = (item) => {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  if (item.code) {
+    return String(item.code);
+  }
+
+  const rank = item.rank ?? "";
+  const name = item.name ?? "";
+
+  if (!rank && !name) {
+    return null;
+  }
+
+  return `${rank}-${name}`;
+};
+
+export const countChangedItems = (firstItems, lastItems) => {
+  const firstList = Array.isArray(firstItems) ? firstItems : [];
+  const lastList = Array.isArray(lastItems) ? lastItems : [];
+
+  const firstMap = new Map();
+
+  firstList.forEach((item) => {
+    const key = getItemIdentifier(item);
+    if (!key) return;
+    firstMap.set(key, JSON.stringify(normalizeItemForComparison(item)));
+  });
+
+  let changes = 0;
+
+  lastList.forEach((item) => {
+    const key = getItemIdentifier(item);
+    const signature = JSON.stringify(normalizeItemForComparison(item));
+
+    if (!key) {
+      changes += 1;
+      return;
+    }
+
+    const previousSignature = firstMap.get(key);
+    if (!previousSignature || previousSignature !== signature) {
+      changes += 1;
+    }
+  });
+
+  return changes;
+};
+
+export const groupSnapshotsByDate = (snapshots) => {
+  const groups = new Map();
+
+  snapshots.forEach((snapshot) => {
+    const asOfDate = toDateInstance(snapshot.asOf);
+    const createdDate = toDateInstance(snapshot.createdAt);
+    const primaryDate = asOfDate || createdDate;
+    const dateKey =
+      toLocalDateKey(primaryDate) || toLocalDateKey(createdDate) || "날짜 미상";
+
+    const comparableTime =
+      (primaryDate && primaryDate.getTime()) ||
+      (createdDate && createdDate.getTime()) ||
+      0;
+
+    const createdAtText = formatTimestamp(snapshot.createdAt);
+    const asOfText = snapshot.asOf || "-";
+    const primaryDisplay = snapshot.asOf || createdAtText;
+
+    const extendedSnapshot = {
+      ...snapshot,
+      _meta: {
+        comparableTime,
+        asOfText,
+        createdAtText,
+        primaryDisplay,
+      },
+    };
+
+    if (!groups.has(dateKey)) {
+      groups.set(dateKey, { dateKey, snapshots: [] });
+    }
+
+    groups.get(dateKey).snapshots.push(extendedSnapshot);
+  });
+
+  const toSortValue = (key) => {
+    const [year, month, day] = key.split("-");
+    if (year && month && day) {
+      const sortDate = new Date(Number(year), Number(month) - 1, Number(day));
+      if (!Number.isNaN(sortDate.getTime())) {
+        return sortDate.getTime();
+      }
+    }
+
+    return -Infinity;
+  };
+
+  return Array.from(groups.values())
+    .map((group) => {
+      const sortedSnapshots = [...group.snapshots].sort(
+        (a, b) => a._meta.comparableTime - b._meta.comparableTime
+      );
+
+      const summary = (() => {
+        if (sortedSnapshots.length === 0) {
+          return { firstTime: "-", lastTime: "-", changedCount: 0 };
+        }
+
+        const firstSnapshot = sortedSnapshots[0];
+        const lastSnapshot = sortedSnapshots[sortedSnapshots.length - 1];
+        const firstItems = Array.isArray(firstSnapshot.items)
+          ? firstSnapshot.items
+          : [];
+        const lastItems = Array.isArray(lastSnapshot.items)
+          ? lastSnapshot.items
+          : [];
+
+        return {
+          firstTime: firstSnapshot._meta.primaryDisplay,
+          lastTime: lastSnapshot._meta.primaryDisplay,
+          changedCount: countChangedItems(firstItems, lastItems),
+        };
+      })();
+
+      return {
+        dateKey: group.dateKey,
+        displayDate: formatDateHeading(group.dateKey),
+        summary,
+        sortValue: toSortValue(group.dateKey),
+        snapshots: sortedSnapshots,
+      };
+    })
+    .sort((a, b) => b.sortValue - a.sortValue);
+};

--- a/src/lib/snapshotUtils.js
+++ b/src/lib/snapshotUtils.js
@@ -1,0 +1,50 @@
+export const normalizeItemForComparison = (item) => {
+  if (!item || typeof item !== "object") {
+    return {};
+  }
+
+  return Object.keys(item)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = item[key];
+      return acc;
+    }, {});
+};
+
+export const normalizeItemsForComparison = (items) => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return [...items]
+    .sort((a, b) => {
+      const rankA =
+        typeof a?.rank === "number"
+          ? a.rank
+          : Number.parseFloat(a?.rank) || Number.MAX_SAFE_INTEGER;
+      const rankB =
+        typeof b?.rank === "number"
+          ? b.rank
+          : Number.parseFloat(b?.rank) || Number.MAX_SAFE_INTEGER;
+
+      if (rankA !== rankB) {
+        return rankA - rankB;
+      }
+
+      const nameA = String(a?.name ?? "");
+      const nameB = String(b?.name ?? "");
+      return nameA.localeCompare(nameB, "ko-KR");
+    })
+    .map(normalizeItemForComparison);
+};
+
+export const buildSnapshotSignature = (asOfValue, items) => {
+  const normalizedAsOf =
+    typeof asOfValue === "string" ? asOfValue : String(asOfValue ?? "");
+  const normalizedItems = normalizeItemsForComparison(items);
+
+  return JSON.stringify({
+    asOf: normalizedAsOf,
+    items: normalizedItems,
+  });
+};

--- a/src/pages/ForeignNetBuyHistory.jsx
+++ b/src/pages/ForeignNetBuyHistory.jsx
@@ -1,19 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { db } from "../firebaseConfig";
 import { collection, onSnapshot, orderBy, query } from "firebase/firestore";
-import {
-  groupSnapshotsByDate,
-} from "../lib/historyUtils";
+import { db } from "../firebaseConfig";
+import { groupSnapshotsByDate } from "../lib/historyUtils";
 
-export default function PopularStocksHistory() {
+export default function ForeignNetBuyHistory() {
   const [snapshots, setSnapshots] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
     const snapshotsQuery = query(
-      collection(db, "popularStocksSnapshots"),
+      collection(db, "foreignNetBuySnapshots"),
       orderBy("asOf", "desc")
     );
 
@@ -28,8 +26,8 @@ export default function PopularStocksHistory() {
         setIsLoading(false);
       },
       (error) => {
-        console.error("[PopularStocksHistory] Firestore 구독 실패", error);
-        setErrorMessage("인기 종목 히스토리를 불러오는 중 오류가 발생했습니다.");
+        console.error("[ForeignNetBuyHistory] Firestore 구독 실패", error);
+        setErrorMessage("외국인 순매수 히스토리를 불러오는 중 오류가 발생했습니다.");
         setIsLoading(false);
       }
     );
@@ -48,9 +46,9 @@ export default function PopularStocksHistory() {
       <header className="bg-gray-800 shadow-md">
         <div className="container mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-white">인기 종목 히스토리</h1>
+            <h1 className="text-2xl font-semibold text-white">외국인 순매수 히스토리</h1>
             <p className="text-sm text-gray-300 mt-1">
-              네이버 금융 인기 검색 종목의 스냅샷을 날짜별로 확인할 수 있습니다.
+              외국인 투자자의 순매수 상위 종목 스냅샷을 날짜별로 확인할 수 있습니다. (단위: 천주, 백만원)
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -61,10 +59,10 @@ export default function PopularStocksHistory() {
               홈으로 돌아가기
             </Link>
             <Link
-              to="/#popular-stocks"
-              className="bg-orange-500 hover:bg-orange-400 text-white text-sm font-semibold py-2 px-4 rounded-md transition duration-300"
+              to="/#foreign-net-buy"
+              className="bg-teal-500 hover:bg-teal-400 text-white text-sm font-semibold py-2 px-4 rounded-md transition duration-300"
             >
-              홈에서 최신 인기 종목 불러오기
+              홈에서 최신 외국인 순매수 불러오기
             </Link>
           </div>
         </div>
@@ -79,7 +77,7 @@ export default function PopularStocksHistory() {
           </div>
         ) : totalSnapshots === 0 ? (
           <div className="p-6 bg-gray-800 rounded-lg text-center text-gray-300">
-            아직 저장된 인기 종목 스냅샷이 없습니다. 홈 화면에서 데이터를 먼저 불러와 주세요.
+            아직 저장된 외국인 순매수 스냅샷이 없습니다. 홈 화면에서 데이터를 먼저 불러와 주세요.
           </div>
         ) : (
           <div className="space-y-8">
@@ -138,53 +136,38 @@ export default function PopularStocksHistory() {
                               <tr>
                                 <th className="px-3 py-2 text-left font-medium">순위</th>
                                 <th className="px-3 py-2 text-left font-medium">종목명</th>
-                                <th className="px-3 py-2 text-left font-medium">현재가</th>
-                                <th className="px-3 py-2 text-left font-medium">전일비</th>
-                                <th className="px-3 py-2 text-left font-medium">등락률</th>
-                                <th className="px-3 py-2 text-left font-medium">거래량</th>
-                                <th className="px-3 py-2 text-left font-medium">검색 비율</th>
+                                <th className="px-3 py-2 text-right font-medium">수량(천주)</th>
+                                <th className="px-3 py-2 text-right font-medium">금액(백만원)</th>
+                                <th className="px-3 py-2 text-right font-medium">당일거래량</th>
                               </tr>
                             </thead>
                             <tbody className="divide-y divide-gray-800 text-gray-300">
                               {items.length === 0 ? (
                                 <tr>
                                   <td
-                                    colSpan={7}
+                                    colSpan={5}
                                     className="px-3 py-4 text-center text-gray-400"
                                   >
-                                    이 시점에 저장된 상세 종목 정보가 없습니다.
+                                    표시할 데이터가 없습니다.
                                   </td>
                                 </tr>
                               ) : (
                                 items.map((item) => {
-                                  const key =
-                                    item.code || `${item.rank}-${item.name}`;
+                                  const key = item.code || `${item.rank}-${item.name}`;
                                   return (
-                                    <tr
-                                      key={key}
-                                      className="hover:bg-gray-700/40 transition duration-150"
-                                    >
-                                      <td className="px-3 py-2 whitespace-nowrap">
-                                        {item.rank ?? "-"}
+                                    <tr key={key}>
+                                      <td className="px-3 py-2 text-left text-gray-300">{item.rank ?? "-"}</td>
+                                      <td className="px-3 py-2 text-left">
+                                        <div className="flex flex-col">
+                                          <span className="text-white font-medium">{item.name}</span>
+                                          {item.code && (
+                                            <span className="text-xs text-gray-400">{item.code}</span>
+                                          )}
+                                        </div>
                                       </td>
-                                      <td className="px-3 py-2 whitespace-nowrap font-medium text-white">
-                                        {item.name ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap">
-                                        {item.price ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap text-gray-300">
-                                        {item.change ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap font-semibold">
-                                        {item.rate ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap text-gray-400">
-                                        {item.volume ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap text-gray-400">
-                                        {item.searchRatio ?? "-"}
-                                      </td>
+                                      <td className="px-3 py-2 text-right font-semibold text-teal-300">{item.quantity || "-"}</td>
+                                      <td className="px-3 py-2 text-right font-semibold text-teal-200">{item.amount || "-"}</td>
+                                      <td className="px-3 py-2 text-right text-gray-300">{item.tradingVolume || "-"}</td>
                                     </tr>
                                   );
                                 })

--- a/src/pages/InstitutionNetBuyHistory.jsx
+++ b/src/pages/InstitutionNetBuyHistory.jsx
@@ -1,19 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { db } from "../firebaseConfig";
 import { collection, onSnapshot, orderBy, query } from "firebase/firestore";
-import {
-  groupSnapshotsByDate,
-} from "../lib/historyUtils";
+import { db } from "../firebaseConfig";
+import { groupSnapshotsByDate } from "../lib/historyUtils";
 
-export default function PopularStocksHistory() {
+export default function InstitutionNetBuyHistory() {
   const [snapshots, setSnapshots] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
     const snapshotsQuery = query(
-      collection(db, "popularStocksSnapshots"),
+      collection(db, "institutionNetBuySnapshots"),
       orderBy("asOf", "desc")
     );
 
@@ -28,8 +26,8 @@ export default function PopularStocksHistory() {
         setIsLoading(false);
       },
       (error) => {
-        console.error("[PopularStocksHistory] Firestore 구독 실패", error);
-        setErrorMessage("인기 종목 히스토리를 불러오는 중 오류가 발생했습니다.");
+        console.error("[InstitutionNetBuyHistory] Firestore 구독 실패", error);
+        setErrorMessage("기관 순매수 히스토리를 불러오는 중 오류가 발생했습니다.");
         setIsLoading(false);
       }
     );
@@ -48,9 +46,9 @@ export default function PopularStocksHistory() {
       <header className="bg-gray-800 shadow-md">
         <div className="container mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <h1 className="text-2xl font-semibold text-white">인기 종목 히스토리</h1>
+            <h1 className="text-2xl font-semibold text-white">기관 순매수 히스토리</h1>
             <p className="text-sm text-gray-300 mt-1">
-              네이버 금융 인기 검색 종목의 스냅샷을 날짜별로 확인할 수 있습니다.
+              기관 투자자의 순매수 상위 종목 스냅샷을 날짜별로 확인할 수 있습니다. (단위: 천주, 백만원)
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -61,10 +59,10 @@ export default function PopularStocksHistory() {
               홈으로 돌아가기
             </Link>
             <Link
-              to="/#popular-stocks"
-              className="bg-orange-500 hover:bg-orange-400 text-white text-sm font-semibold py-2 px-4 rounded-md transition duration-300"
+              to="/#institution-net-buy"
+              className="bg-teal-500 hover:bg-teal-400 text-white text-sm font-semibold py-2 px-4 rounded-md transition duration-300"
             >
-              홈에서 최신 인기 종목 불러오기
+              홈에서 최신 기관 순매수 불러오기
             </Link>
           </div>
         </div>
@@ -79,7 +77,7 @@ export default function PopularStocksHistory() {
           </div>
         ) : totalSnapshots === 0 ? (
           <div className="p-6 bg-gray-800 rounded-lg text-center text-gray-300">
-            아직 저장된 인기 종목 스냅샷이 없습니다. 홈 화면에서 데이터를 먼저 불러와 주세요.
+            아직 저장된 기관 순매수 스냅샷이 없습니다. 홈 화면에서 데이터를 먼저 불러와 주세요.
           </div>
         ) : (
           <div className="space-y-8">
@@ -138,53 +136,38 @@ export default function PopularStocksHistory() {
                               <tr>
                                 <th className="px-3 py-2 text-left font-medium">순위</th>
                                 <th className="px-3 py-2 text-left font-medium">종목명</th>
-                                <th className="px-3 py-2 text-left font-medium">현재가</th>
-                                <th className="px-3 py-2 text-left font-medium">전일비</th>
-                                <th className="px-3 py-2 text-left font-medium">등락률</th>
-                                <th className="px-3 py-2 text-left font-medium">거래량</th>
-                                <th className="px-3 py-2 text-left font-medium">검색 비율</th>
+                                <th className="px-3 py-2 text-right font-medium">수량(천주)</th>
+                                <th className="px-3 py-2 text-right font-medium">금액(백만원)</th>
+                                <th className="px-3 py-2 text-right font-medium">당일거래량</th>
                               </tr>
                             </thead>
                             <tbody className="divide-y divide-gray-800 text-gray-300">
                               {items.length === 0 ? (
                                 <tr>
                                   <td
-                                    colSpan={7}
+                                    colSpan={5}
                                     className="px-3 py-4 text-center text-gray-400"
                                   >
-                                    이 시점에 저장된 상세 종목 정보가 없습니다.
+                                    표시할 데이터가 없습니다.
                                   </td>
                                 </tr>
                               ) : (
                                 items.map((item) => {
-                                  const key =
-                                    item.code || `${item.rank}-${item.name}`;
+                                  const key = item.code || `${item.rank}-${item.name}`;
                                   return (
-                                    <tr
-                                      key={key}
-                                      className="hover:bg-gray-700/40 transition duration-150"
-                                    >
-                                      <td className="px-3 py-2 whitespace-nowrap">
-                                        {item.rank ?? "-"}
+                                    <tr key={key}>
+                                      <td className="px-3 py-2 text-left text-gray-300">{item.rank ?? "-"}</td>
+                                      <td className="px-3 py-2 text-left">
+                                        <div className="flex flex-col">
+                                          <span className="text-white font-medium">{item.name}</span>
+                                          {item.code && (
+                                            <span className="text-xs text-gray-400">{item.code}</span>
+                                          )}
+                                        </div>
                                       </td>
-                                      <td className="px-3 py-2 whitespace-nowrap font-medium text-white">
-                                        {item.name ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap">
-                                        {item.price ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap text-gray-300">
-                                        {item.change ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap font-semibold">
-                                        {item.rate ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap text-gray-400">
-                                        {item.volume ?? "-"}
-                                      </td>
-                                      <td className="px-3 py-2 whitespace-nowrap text-gray-400">
-                                        {item.searchRatio ?? "-"}
-                                      </td>
+                                      <td className="px-3 py-2 text-right font-semibold text-teal-300">{item.quantity || "-"}</td>
+                                      <td className="px-3 py-2 text-right font-semibold text-teal-200">{item.amount || "-"}</td>
+                                      <td className="px-3 py-2 text-right text-gray-300">{item.tradingVolume || "-"}</td>
                                     </tr>
                                   );
                                 })


### PR DESCRIPTION
## Summary
- add Netlify functions that scrape and normalize foreign and institution net-buy rankings from Naver Finance
- show the new ranking sections on the home page with Firestore-backed persistence and fallbacks
- provide dedicated history pages and shared utilities for snapshot grouping alongside the existing popular stocks history

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53525d57883238970363f161a9a2d